### PR TITLE
Added native_routine_registration the correct way

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -1,0 +1,40 @@
+#include <stdlib.h> // for NULL
+#include <R_ext/Rdynload.h>
+
+/* FIXME: 
+   Check these declarations against the C/Fortran source code.
+*/
+
+/* .C calls */
+extern void cBase2C(void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *);
+extern void cBaseeco(void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *);
+extern void cBaseecoX(void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *);
+extern void cBaseecoZ(void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *);
+extern void cBaseRC(void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *);
+extern void cDPeco(void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *);
+extern void cDPecoX(void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *);
+extern void cEMeco(void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *);
+extern void preBaseX(void *, void *, void *, void *, void *, void *, void *);
+extern void preDP(void *, void *, void *, void *, void *, void *, void *);
+extern void preDPX(void *, void *, void *, void *, void *, void *, void *, void *);
+
+static const R_CMethodDef CEntries[] = {
+    {"cBase2C",   (DL_FUNC) &cBase2C,   22},
+    {"cBaseeco",  (DL_FUNC) &cBaseeco,  32},
+    {"cBaseecoX", (DL_FUNC) &cBaseecoX, 36},
+    {"cBaseecoZ", (DL_FUNC) &cBaseecoZ, 29},
+    {"cBaseRC",   (DL_FUNC) &cBaseRC,   23},
+    {"cDPeco",    (DL_FUNC) &cDPeco,    36},
+    {"cDPecoX",   (DL_FUNC) &cDPecoX,   40},
+    {"cEMeco",    (DL_FUNC) &cEMeco,    27},
+    {"preBaseX",  (DL_FUNC) &preBaseX,   7},
+    {"preDP",     (DL_FUNC) &preDP,      7},
+    {"preDPX",    (DL_FUNC) &preDPX,     8},
+    {NULL, NULL, 0}
+};
+
+void R_init_eco(DllInfo *dll)
+{
+    R_registerRoutines(dll, CEntries, NULL, NULL, NULL);
+    R_useDynamicSymbols(dll, FALSE);
+}

--- a/src/registerDynamicSymbols.c
+++ b/src/registerDynamicSymbols.c
@@ -1,9 +1,0 @@
-#include <R.h>
-#include <Rinternals.h>
-#include <R_ext/Rdynload.h>
-
-void R_init_markovchain(DllInfo* info) {
-  R_registerRoutines(info, NULL, NULL, NULL, NULL);
-  R_useDynamicSymbols(info, TRUE);
-}
-


### PR DESCRIPTION
The added file for routine_registration, init.c, was automatically generated by tools::package_native_routine_registration_skeleton(".")

I also tested and confirmed that the test output is the same using kosukeimai/eco vs HJ08003/eco.

Note: win-builder still says there is 1 ERROR for installing the package on arch = i368. But I have installed the package on a Win7 laptop without any problems. 